### PR TITLE
14 add pooling layers

### DIFF
--- a/src/tensor/autodiff.py
+++ b/src/tensor/autodiff.py
@@ -257,17 +257,16 @@ class Tensor():
     # end of movement operations
 
 
-    def sum(self) -> Tensor:
+    def sum(self, dim=None) -> Tensor:
         output = Tensor(
-            np.sum(self.data),
+            np.sum(self.data, axis=dim),
             requires_grad=True if self.requires_grad else False,
             parent = (self,),
             op="sum",
             name=f"sum({self.name})"
         )
         def _backward():
-            assert output.grad.shape == ()
-            self.grad += np.full(self.data.shape, output.grad.item())
+            self.grad += np.expand_dims(output.grad, dim if dim else 0)
         output._backward = _backward
         return output
 

--- a/src/tensor/autodiff.py
+++ b/src/tensor/autodiff.py
@@ -281,6 +281,10 @@ class Tensor():
 
     def mean(self, dim=None) -> Tensor:
         out = self.sum(dim)
+        if isinstance(dim, int):
+            if dim == -1:
+                dim = len(out.shape)
+            dim = (dim,)
         div = Tensor(np.array(np.prod(out.shape), dtype=np.float32), True).expand((s for i,s in enumerate(self.shape) if i not in dim)) if dim else self.data.size
         return out / div
 

--- a/src/tensor/autodiff.py
+++ b/src/tensor/autodiff.py
@@ -175,7 +175,6 @@ class Tensor():
         return output
 
     def __truediv__(self, other: Union[int,float]) ->Tensor:
-        assert isinstance(other, (int,float))
         return self * other ** (-1)
     
 
@@ -270,8 +269,10 @@ class Tensor():
         output._backward = _backward
         return output
 
-    def mean(self) -> Tensor:
-        return self.sum() / self.data.size
+    def mean(self, dim=None) -> Tensor:
+        out = self.sum(dim)
+        div = Tensor(np.array(np.prod(out.shape), dtype=np.float32), True).expand((s for i,s in enumerate(self.shape) if i not in dim)) if dim else self.data.size
+        return out / div
 
     def max(self, dim: int = None) -> Tensor:
         # NOTE: max() != max(axis=0)

--- a/src/tensor/nn/module.py
+++ b/src/tensor/nn/module.py
@@ -254,7 +254,7 @@ class MaxPool3d(Module):
 
     def forward(self, x: Tensor) -> Tensor:
         assert len(x.shape) == 5, "MaxPool3d only supports batched inputs"
-        padded_x = x.pad(((0,0),(0,0),*self.padding)) if any(pad > 0 for tup in self.padding for pad in tup) else x
+        padded_x = x.pad(((0,0),(0,0),*self.padding), -np.inf) if any(pad > 0 for tup in self.padding for pad in tup) else x
         Dout, Hout, Wout = self.__compute_out_dim(x.shape[-3], x.shape[-2], x.shape[-1])
         expanded_view = padded_x.stride((padded_x.shape[0], padded_x.shape[1], *self.kernel_size), self.stride[0])
         return expanded_view.max(-1).max(-1).max(-1).reshape((Dout, Hout, Wout, x.shape[0], x.shape[1])).permute((3,4,0,1,2))
@@ -281,12 +281,76 @@ class AvgPool1d(Module):
     
 
     def forward(self, x: Tensor) -> Tensor:
-        assert len(x.shape) == 3, "MaxPool1d only supports batched inputs"
+        assert len(x.shape) == 3, "AvgPool1d only supports batched inputs"
         padded_x = x.pad(((0,0),(0,0),*self.padding),0) if any(pad > 0 for tup in self.padding for pad in tup) else x
         Lout = self.__compute_out_length(x.shape[-1])
         expanded_view = padded_x.stride((padded_x.shape[0], padded_x.shape[1], self.kernel_size), self.stride)
         return (expanded_view.sum(-1).reshape((Lout, x.shape[0], x.shape[1])) / float(np.prod(self.kernel_size))).permute((1,2,0))
 
+class AvgPool2d(Module):
+    def __init__(
+        self,
+        kernel_size:tuple[int],
+        stride:int = None,
+        padding: tuple[tuple] = ((0,0),(0,0))
+        ) -> None:
+        super().__init__()
+        self.kernel_size = kernel_size
+        self.stride = stride if stride else kernel_size
+        self.padding = padding
+
+    def __compute_out_dim(self, Hin, Win) -> tuple[int, int]:
+        assert self.padding[0][0] == self.padding[0][1]
+        assert self.padding[1][0] == self.padding[1][1]
+        Hout = np.floor(
+            (Hin + 2*self.padding[0][0] - self.kernel_size[0])/self.stride[0] + 1
+        )
+        Wout = np.floor(
+            (Win + 2*self.padding[1][0] - self.kernel_size[1])/self.stride[1] + 1
+        )
+        return int(Hout), int(Wout)
+    
+    def forward(self, x: Tensor) -> Tensor:
+        assert len(x.shape) == 4, "AvgPool2d only supports batched inputs"
+        padded_x = x.pad(((0,0),(0,0),*self.padding), 0) if any(pad > 0 for tup in self.padding for pad in tup) else x
+        Hout, Wout = self.__compute_out_dim(x.shape[-2], x.shape[-1])
+        expanded_view = padded_x.stride((padded_x.shape[0], padded_x.shape[1], self.kernel_size[0], self.kernel_size[1]), stride = self.stride[0])
+        return (expanded_view.sum((-1,-2)).reshape((Hout,Wout,x.shape[0], x.shape[1])) / float(np.prod(self.kernel_size))).permute((2,3,0,1))
+
+
+class AvgPool3d(Module):
+    def __init__(
+        self,
+        kernel_size: tuple,
+        stride: tuple=None,
+        padding:tuple[tuple]=((0,0), (0,0), (0,0)),
+        ) -> None:
+        super().__init__()
+        self.kernel_size = kernel_size
+        self.stride = stride if stride else kernel_size
+        self.padding = padding
+
+    def __compute_out_dim(self, Din, Hin, Win) -> tuple[int,int,int]:
+        pad0 = self.padding[0][0]
+        pad1 = self.padding[1][0]
+        pad2 = self.padding[2][0]
+        Dout = np.floor(
+            (Din + 2*pad0 - self.kernel_size[0])/ self.stride[0] + 1
+        )
+        Hout = np.floor(
+            (Hin + 2*pad1 - self.kernel_size[1])/ self.stride[1] + 1
+        )
+        Wout = np.floor(
+            (Win + 2*pad2 - self.kernel_size[2])/ self.stride[2] + 1
+        )
+        return int(Dout), int(Hout), int(Wout)    
+
+    def forward(self, x: Tensor) -> Tensor:
+        assert len(x.shape) == 5, "MaxPool3d only supports batched inputs"
+        padded_x = x.pad(((0,0),(0,0),*self.padding)) if any(pad > 0 for tup in self.padding for pad in tup) else x
+        Dout, Hout, Wout = self.__compute_out_dim(x.shape[-3], x.shape[-2], x.shape[-1])
+        expanded_view = padded_x.stride((padded_x.shape[0], padded_x.shape[1], *self.kernel_size), self.stride[0])
+        return (expanded_view.sum((-3,-2,-1)).reshape((Dout, Hout, Wout, x.shape[0], x.shape[1])) / float(np.prod(self.kernel_size))).permute((3,4,0,1,2))
 
 
 class Sum(Module):

--- a/test/test_tensor/test_tensor_autodiff.py
+++ b/test/test_tensor/test_tensor_autodiff.py
@@ -263,10 +263,10 @@ def test_max_with_axis_forward_pass():
 
 def test_max_with_axis_backward_pass():
     a = Tensor.random((3,3,28,28))
-    b = a.max(2)
+    b = a.max(-1).max(-1)
     b.backward()
     torch_a = torch.tensor(a.data, requires_grad=True)
-    torch_b = torch_a.max(2)[0]
+    torch_b = torch_a.max(-1)[0].max(-1)[0]
     torch_b.backward(torch.ones_like(torch_b))
     assert np.all(abs(a.grad - torch_a.grad.numpy()) < 0.00000001)
 

--- a/test/test_tensor/test_tensor_autodiff.py
+++ b/test/test_tensor/test_tensor_autodiff.py
@@ -198,11 +198,21 @@ def test_sum_backward_pass():
 
 def test_sum_with_axis_forward_pass():
     a = Tensor.random((3,3,28,28))
+    b = a.sum(1)
+    torch_a = torch.tensor(a.data)
+    torch_b = torch_a.sum(1)
+    assert b.shape == torch_b.shape, "shape not equal"
+    assert np.all(abs(b.data - torch_b.detach().numpy()) < 0.00000001)
+
+
+def test_sum_with_multiple_axis_forward_pass():
+    a = Tensor.random((3,3,28,28))
     b = a.sum((1,3))
     torch_a = torch.tensor(a.data)
     torch_b = torch_a.sum((1,3))
     assert b.shape == torch_b.shape, "shape not equal"
     assert np.all(abs(b.data - torch_b.detach().numpy()) < 0.00000001)
+
 
 def test_sum_with_axis_backward_pass():
     a = Tensor.random((3,3,28,28))
@@ -223,12 +233,21 @@ def test_mean_backward_pass():
     assert np.all(a.grad == c.grad.numpy())
 
 def test_mean_with_axis_forward_pass():
+    a = Tensor.random((1,1,10,10))
+    b = a.mean(2)
+    torch_a = torch.tensor(a.data)
+    torch_b = torch_a.mean(2)
+    assert b.shape == torch_b.shape, "shape not equal"
+    assert np.all(abs(b.data - torch_b.detach().numpy()) < 0.0000001)
+
+def test_mean_with_multiple_axis_forward_pass():
     a = Tensor.random((3,3,28,28))
     b = a.mean((1,3))
-    torch_a = torch.tensor(a.data)
+    torch_a = torch.tensor(a.data, requires_grad=True)
     torch_b = torch_a.mean((1,3))
     assert b.shape == torch_b.shape, "shape not equal"
-    assert np.all(abs(b.data - torch_b.detach().numpy()) < 0.00000001)
+    assert np.all(abs(b.data - torch_b.detach().numpy()) < 0.0000001)
+
 
 def test_mean_with_axis_backward_pass():
     a = Tensor.random((3,3,28,28))

--- a/test/test_tensor/test_tensor_autodiff.py
+++ b/test/test_tensor/test_tensor_autodiff.py
@@ -205,6 +205,11 @@ def test_mean_backward_pass():
     d.backward(torch.ones_like(d))
     assert np.all(a.grad == c.grad.numpy())
 
+def test_max_forward_pass():
+    a = Tensor.random((2,3,4,4))
+    torch_a = torch.tensor(a.data)
+    assert a.max().data == torch_a.max().detach().numpy()
+
 def test_max_backward_pass():
     a = Tensor(np.array([[1.0,2],[2,1]]), requires_grad=True)
     b = a.max() * 3
@@ -213,6 +218,23 @@ def test_max_backward_pass():
     d = c.max() * 3
     d.backward()
     assert np.all(a.grad == c.grad.numpy())
+
+def test_max_with_axis_forward_pass():
+    a = Tensor.random((3,3,28,28))
+    b = a.max(2)
+    torch_a = torch.tensor(a.data, dtype=torch.float64)
+    torch_b = torch_a.max(2)[0]
+    assert b.shape == torch_b.shape, "shape not equal"
+    assert np.all(abs(b.data - torch_b.detach().numpy()) < 0.00000001), "result not equal"
+
+def test_max_with_axis_backward_pass():
+    a = Tensor.random((3,3,28,28))
+    b = a.max(2)
+    b.backward()
+    torch_a = torch.tensor(a.data, requires_grad=True)
+    torch_b = torch_a.max(2)[0]
+    torch_b.backward(torch.ones_like(torch_b))
+    assert np.all(abs(a.grad - torch_a.grad.numpy()) < 0.00000001)
 
 def test_relu_backward_pass():
     a = Tensor(np.array([[-1.0,2], [-3,2]]), requires_grad=True)

--- a/test/test_tensor/test_tensor_autodiff.py
+++ b/test/test_tensor/test_tensor_autodiff.py
@@ -196,6 +196,23 @@ def test_sum_backward_pass():
     d.backward()
     assert np.all(a.grad == c.grad.numpy())
 
+def test_sum_with_axis_forward_pass():
+    a = Tensor.random((3,3,28,28))
+    b = a.sum((1,3))
+    torch_a = torch.tensor(a.data)
+    torch_b = torch_a.sum((1,3))
+    assert b.shape == torch_b.shape, "shape not equal"
+    assert np.all(abs(b.data - torch_b.detach().numpy()) < 0.00000001)
+
+def test_sum_with_axis_backward_pass():
+    a = Tensor.random((3,3,28,28))
+    b = a.sum((1,3))
+    torch_a = torch.tensor(a.data, requires_grad=True)
+    torch_b = torch_a.sum((1,3))
+    b.backward()
+    torch_b.backward(torch.ones_like(torch_b))
+    assert np.all(abs(a.grad - torch_a.grad.detach().numpy()) < 0.00000001)
+
 def test_mean_backward_pass():
     a = Tensor(np.array([[1.0,2],[2,1]]), requires_grad=True)
     b = a.mean()

--- a/test/test_tensor/test_tensor_autodiff.py
+++ b/test/test_tensor/test_tensor_autodiff.py
@@ -222,6 +222,23 @@ def test_mean_backward_pass():
     d.backward(torch.ones_like(d))
     assert np.all(a.grad == c.grad.numpy())
 
+def test_mean_with_axis_forward_pass():
+    a = Tensor.random((3,3,28,28))
+    b = a.mean((1,3))
+    torch_a = torch.tensor(a.data)
+    torch_b = torch_a.mean((1,3))
+    assert b.shape == torch_b.shape, "shape not equal"
+    assert np.all(abs(b.data - torch_b.detach().numpy()) < 0.00000001)
+
+def test_mean_with_axis_backward_pass():
+    a = Tensor.random((3,3,28,28))
+    b = a.mean((1,3))
+    torch_a = torch.tensor(a.data, requires_grad=True)
+    torch_b = torch_a.mean((1,3))
+    b.backward()
+    torch_b.backward(torch.ones_like(torch_b))
+    assert np.all(abs(a.grad - torch_a.grad.numpy()) < 0.00000001)
+
 def test_max_forward_pass():
     a = Tensor.random((2,3,4,4))
     torch_a = torch.tensor(a.data)

--- a/test/test_tensor/test_tensor_module.py
+++ b/test/test_tensor/test_tensor_module.py
@@ -340,3 +340,24 @@ def test_max_pool3d_with_padding_and_stride_forward_pass():
     assert out.shape == torch_out.shape, "shape not equal"
     assert np.all(abs(out.data - torch_out.detach().numpy()) < 0.00000001), "result not equal"
     
+
+def test_avgpool1d_forward_pass():
+    x = Tensor.random((3,3,20))
+    pool = AvgPool1d(3)
+    out = pool(x)
+    torch_x = torch.tensor(x.data)
+    torch_pool = torch.nn.AvgPool1d(3)
+    torch_out = torch_pool(torch_x)
+    assert out.shape == torch_out.shape, "shape not equal"
+    assert np.all(abs(out.data - torch_out.detach().numpy()) < 0.0000001), "result not equal"
+
+def test_avgpool1d_with_padding_and_stride_forward_pass():
+    x = Tensor.random((3,3,20))
+    pool = AvgPool1d(3, 2, ((1,1),))
+    out = pool(x)
+    torch_x = torch.tensor(x.data)
+    torch_pool = torch.nn.AvgPool1d(3,2, 1)
+    torch_out = torch_pool(torch_x)
+    assert out.shape == torch_out.shape, "shape not equal"
+    assert np.all(abs(out.data - torch_out.detach().numpy()) < 0.0000001), "result not equal"
+    

--- a/test/test_tensor/test_tensor_module.py
+++ b/test/test_tensor/test_tensor_module.py
@@ -361,3 +361,43 @@ def test_avgpool1d_with_padding_and_stride_forward_pass():
     assert out.shape == torch_out.shape, "shape not equal"
     assert np.all(abs(out.data - torch_out.detach().numpy()) < 0.0000001), "result not equal"
     
+def test_avgpool2d_forward_pass():
+    x = Tensor.random((3,3,10,10))
+    pool = AvgPool2d((3,3))
+    out = pool(x)
+    torch_x = torch.tensor(x.data)
+    torch_pool = torch.nn.AvgPool2d(3)
+    torch_out = torch_pool(torch_x)
+    assert out.shape == torch_out.shape, "shape not equal"
+    assert np.all(abs(out.data - torch_out.detach().numpy()) < 0.0000001), "result not equal"
+    
+def test_avgpool2d_with_padding_and_stride_forward_pass():
+    x = Tensor.random((3,3,10,10))
+    pool = AvgPool2d((3,3), (2,2), ((1,1), (1,1)))
+    out = pool(x)
+    torch_x = torch.tensor(x.data)
+    torch_pool = torch.nn.AvgPool2d(3,2,1)
+    torch_out = torch_pool(torch_x)
+    assert out.shape == torch_out.shape, "shape not equal"
+    assert np.all(abs(out.data - torch_out.detach().numpy()) < 0.0000001), "result not equal"
+    
+def test_avgpool3d_forward_pass():
+    x = Tensor.random((3,3,10,10,10))
+    pool = AvgPool3d((3,3,3))
+    out = pool(x)
+    torch_x = torch.tensor(x.data)
+    torch_pool = torch.nn.AvgPool3d(3)
+    torch_out = torch_pool(torch_x)
+    assert out.shape == torch_out.shape, "shape not equal"
+    assert np.all(abs(out.data - torch_out.detach().numpy()) < 0.00000001), "result not equal"
+
+def test_avgpool3d_with_padding_and_stride_forward_pass():
+    x = Tensor.random((3,3,10,10,10))
+    pool = AvgPool3d((3,3,3), (2,2,2), ((1,1), (1,1), (1,1)))
+    out = pool(x)
+    torch_x = torch.tensor(x.data)
+    torch_pool = torch.nn.AvgPool3d(3,2,1)
+    torch_out = torch_pool(torch_x)
+    assert out.shape == torch_out.shape, "shape not equal"
+    assert np.all(abs(out.data - torch_out.detach().numpy()) < 0.00000001), "result not equal"
+

--- a/test/test_tensor/test_tensor_module.py
+++ b/test/test_tensor/test_tensor_module.py
@@ -265,6 +265,27 @@ def test_conv3d_pad_and_stride_backward_pass():
     assert np.all(abs(conv.b.grad - torch_conv.bias.grad.detach().numpy()) < 0.00000001)
     
 
+def test_maxpool1d_forward_pass():
+    x = Tensor.random((32,3,20))
+    pool = MaxPool1d(3)
+    out = pool(x)
+    torch_x = torch.tensor(x.data)
+    torch_pool = torch.nn.MaxPool1d(3)
+    torch_out = torch_pool(torch_x)
+    assert out.shape == torch_out.shape, "shape not equal"
+    assert np.all(abs(out.data - torch_out.detach().numpy()) < 0.00000001), "result not equal"
+
+def test_maxpool1d_with_padding_and_stride_forward_pass():
+    x = Tensor.random((32,3,20))
+    pool = MaxPool1d(3, 2, ((1,1),))
+    out = pool(x)
+    torch_x = torch.tensor(x.data)
+    torch_pool = torch.nn.MaxPool1d(3,2, 1)
+    torch_out = torch_pool(torch_x)
+    assert out.shape == torch_out.shape, "shape not equal"
+    assert np.all(abs(out.data - torch_out.detach().numpy()) < 0.00000001), "result not equal"
+    
+
 def test_maxpool2d_forward_pass():
     x = Tensor.random((32,3,28,28))
     pool = MaxPool2d((3,3))

--- a/test/test_tensor/test_tensor_module.py
+++ b/test/test_tensor/test_tensor_module.py
@@ -320,3 +320,23 @@ def test_maxpool2d_backward_pass():
     torch_out.backward()
     assert np.all(abs(x.grad - torch_x.grad.detach().numpy()) < 0.00001), "result not equal"
     
+def test_maxpool3d_forward_pass():
+    x = Tensor.random((3,3,10,10,10))
+    pool = MaxPool3d((3,3,3))
+    out = pool(x)
+    torch_x = torch.tensor(x.data)
+    torch_pool = torch.nn.MaxPool3d(3)
+    torch_out = torch_pool(torch_x)
+    assert out.shape == torch_out.shape, "shape not equal"
+    assert np.all(abs(out.data - torch_out.detach().numpy()) < 0.00000001), "result not equal"
+
+def test_max_pool3d_with_padding_and_stride_forward_pass():
+    x = Tensor.random((3,3,10,10,10))
+    pool = MaxPool3d((3,3,3), (2,2,2,), ((1,1), (1,1), (1,1)))
+    out = pool(x)
+    torch_x = torch.tensor(x.data)
+    torch_pool = torch.nn.MaxPool3d(3,2,1)
+    torch_out = torch_pool(torch_x)
+    assert out.shape == torch_out.shape, "shape not equal"
+    assert np.all(abs(out.data - torch_out.detach().numpy()) < 0.00000001), "result not equal"
+    


### PR DESCRIPTION
There is a bug in the backward pass of Tensor.stride: for now we can ignore it as we never stride a weight or anything that requires a gradient. The potential fix is to implement the rolling window natively using other tensor methods so we can keep track of everything needed to properly reverse it. 

There's a lot of repeated code in the Conv and Pool layers, this is because they are all essentially the same thing with a different op at the end, we should refactor eventually and maybe break down the module file in several files