### PR TITLE
20 fix stride

### DIFF
--- a/test/test_tensor/test_tensor_autodiff.py
+++ b/test/test_tensor/test_tensor_autodiff.py
@@ -459,9 +459,9 @@ def test_as_strided_backward_pass():
     new_shape = (1,1,3,3,1,1,3,3)
     strides = (100,100,20,4,100,100,20,4)
     torch_strides = tuple(s//4 for s in strides) #needed because of the different mechanism numpy and torch use to store data
-    out = x.as_strided(new_shape, strides).mean()
-    torch_out = torch_x.as_strided(new_shape, torch_strides).mean()
+    out = (x.as_strided(new_shape, strides) ** 2).mean() * 10
+    torch_out = (torch_x.as_strided(new_shape, torch_strides) ** 2).mean() * 10
     out.backward()
     torch_out.backward()
-    assert(np.all(x.grad == torch_x.grad.detach().numpy()))
+    assert(np.all(abs(x.grad - torch_x.grad.detach().numpy()) < 1e-6))
 

--- a/test/test_tensor/test_tensor_autodiff.py
+++ b/test/test_tensor/test_tensor_autodiff.py
@@ -442,30 +442,6 @@ def test_squeeze_backward_pass():
     assert np.all(a.grad == torch_a.grad.detach().numpy()), "a.grad incorrect"
     assert np.all(b.grad == torch_b.grad.detach().numpy()), "b.grad incorrect"
     
-def test_as_strided_forward_pass():
-    x = Tensor.random((1,1,5,5), dtype = np.float32)
-    torch_x = torch.from_numpy(x.data)
-    new_shape = (1,1,3,3,1,1,3,3)
-    strides = (100,100,20,4,100,100,20,4)
-    torch_strides = tuple(s//4 for s in strides) #needed because of the different mechanism numpy and torch use to store data
-    out = x.as_strided(new_shape, strides)
-    torch_out = torch_x.as_strided(new_shape, torch_strides)
-    assert np.all(out.shape == torch_out.shape), "shapes not equal"
-    assert np.all(out.data == torch_out.numpy()), "output not equal" 
-
-def test_as_strided_backward_pass():
-    x = Tensor.random((1,1,5,5), dtype = np.float32)
-    torch_x = torch.tensor(x.data, requires_grad=True)
-    new_shape = (1,1,3,3,1,1,3,3)
-    strides = (100,100,20,4,100,100,20,4)
-    torch_strides = tuple(s//4 for s in strides) #needed because of the different mechanism numpy and torch use to store data
-    out = (x.as_strided(new_shape, strides) ** 2).max() * 10
-    torch_out = (torch_x.as_strided(new_shape, torch_strides) ** 2).max() * 10
-    out.backward()
-    torch_out.backward()
-    print(x.grad)
-    print(torch_x.grad)
-    assert(np.all(abs(x.grad - torch_x.grad.detach().numpy()) < 1e-6))
 
 def test_cat_forward_pass():
     tensors = [Tensor.random((1,1,5+i,5)) for i in range(3)]

--- a/test/test_tensor/test_tensor_autodiff.py
+++ b/test/test_tensor/test_tensor_autodiff.py
@@ -484,3 +484,37 @@ def test_cat_backward_pass():
     torch_out = torch_big_tensor.mean()
     out.backward()
     torch_out.backward()
+
+def test_unsqueeze_forward_pass():
+    x = Tensor.random((3,3,2,2))
+    x_unsqueezed = x.unsqueeze(1)
+    assert x_unsqueezed.shape == (3,1,3,2,2), "shape incorrect"
+    assert np.all(x_unsqueezed[:,0,:,:,:].data == x.data), "data incorrect"
+
+def test_unsqueeze_backward_pass():
+    x = Tensor.random((3,3,2,2))
+    torch_x = torch.tensor(x.data, requires_grad=True)
+    out = x.unsqueeze(1).sum()
+    torch_out = torch_x.unsqueeze(1).sum()
+    out.backward()
+    torch_out.backward()
+    assert np.all(x.grad == torch_x.grad.detach().numpy()), "grad incorrect"
+
+def test_unfold_forward_pass():
+    x = Tensor.random((4,4,5,5))
+    torch_x = torch.tensor(x.data)
+    unfolded = x.unfold(1,2,1)
+    torch_unfolded = torch_x.unfold(1,2,1)
+    assert unfolded.shape == torch_unfolded.shape, "shape incorrect"
+    assert np.all(unfolded.data == torch_unfolded.numpy()), "output incorrect"
+
+def test_unfold_backward_pass():
+    x = Tensor.random((4,4,5,5))
+    torch_x = torch.tensor(x.data, requires_grad=True)
+    unfolded = x.unfold(1,2,1)
+    torch_unfolded = torch_x.unfold(1,2,1)
+    out = unfolded.sum()
+    torch_out = torch_unfolded.sum()
+    out.backward()
+    torch_out.backward()
+    assert np.all(x.grad == torch_x.grad.detach().numpy()), "grad incorrect"

--- a/test/test_tensor/test_tensor_module.py
+++ b/test/test_tensor/test_tensor_module.py
@@ -307,7 +307,6 @@ def test_maxpool2d_with_padding_and_stride_forward_pass():
     assert out.shape == torch_out.shape, "shape not equal"
     assert np.all(abs(out.data - torch_out.detach().numpy()) < 0.00000001), "result not equal"
     
-@pytest.mark.skip(reason="fails but not criticial because backward through a pool almost never happens")
 def test_maxpool2d_backward_pass():
     x = Tensor.random((1,1,10,10), name="x")
     torch_x = torch.tensor(x.data, requires_grad=True)

--- a/test/test_tensor/test_tensor_module.py
+++ b/test/test_tensor/test_tensor_module.py
@@ -318,6 +318,8 @@ def test_maxpool2d_backward_pass():
     torch_pooled = torch_pool(torch_x)
     torch_out = torch_pooled.sum()
     torch_out.backward()
+    print(x.grad)
+    print(torch_x.grad)
     assert np.all(abs(x.grad - torch_x.grad.detach().numpy()) < 0.0000001), "result not equal"
     
 def test_maxpool3d_forward_pass():

--- a/test/test_tensor/test_tensor_module.py
+++ b/test/test_tensor/test_tensor_module.py
@@ -227,7 +227,7 @@ def test_conv1d_pad_and_stride_backward_pass():
     assert np.all(abs(conv.b.grad - torch_conv.bias.grad.detach().numpy()) < 0.00000001)
     
 def test_conv3d_output():
-    x = Tensor.random((32,3,32,28,28))
+    x = Tensor.random((1,3,10,16,16))
     conv = Conv3d(3,6,(3,3,3))
     torch_x = torch.tensor(x.data, dtype=torch.float64)
     torch_conv = torch.nn.Conv3d(3,6,3)
@@ -238,7 +238,7 @@ def test_conv3d_output():
     assert np.all(abs(out.data - torch_out.detach().numpy()) < 0.00000001)
 
 def test_conv3d_backward_pass():
-    x = Tensor.random((32,3,32,28,28))
+    x = Tensor.random((1,3,10,16,16))
     conv = Conv3d(3,6,(3,3,3))
     torch_x = torch.tensor(x.data, dtype=torch.float64)
     torch_conv = torch.nn.Conv3d(3,6,3)
@@ -252,7 +252,7 @@ def test_conv3d_backward_pass():
     assert np.all(abs(conv.b.grad - torch_conv.bias.grad.detach().numpy()) < 0.00000001)
     
 def test_conv3d_pad_and_stride_backward_pass():
-    x = Tensor.random((32,3,32,28,28))
+    x = Tensor.random((1,3,10,16,16))
     conv = Conv3d(3,6,(3,3,3), ((2,2,2)), ((1,1), (2,2), (1,1)))
     torch_x = torch.tensor(x.data, dtype=torch.float64)
     torch_conv = torch.nn.Conv3d(3,6,3, 2, (1,2,1))
@@ -318,7 +318,7 @@ def test_maxpool2d_backward_pass():
     torch_pooled = torch_pool(torch_x)
     torch_out = torch_pooled.sum()
     torch_out.backward()
-    assert np.all(abs(x.grad - torch_x.grad.detach().numpy()) < 0.00001), "result not equal"
+    assert np.all(abs(x.grad - torch_x.grad.detach().numpy()) < 0.0000001), "result not equal"
     
 def test_maxpool3d_forward_pass():
     x = Tensor.random((3,3,10,10,10))

--- a/yadll/tensor/autodiff.py
+++ b/yadll/tensor/autodiff.py
@@ -192,6 +192,7 @@ class Tensor():
             self.name
         )
         def _backward():
+            print(f"{self.grad.shape=}, {output.grad.shape=}, {order=}")
             self.grad += np.transpose(output.grad, np.argsort(order)) #using argsort transpose output.grad back to initial shape
 
         output._backward = _backward
@@ -284,6 +285,16 @@ class Tensor():
             out += t.pad(pad)
             running_shape += t.shape[dim]
         return out
+
+    def unfold(self, dimension: int, size: int, step: int) -> Tensor:
+        sizedim = self.shape[dimension]
+        slices = [tuple(slice(None, None, 1) if i!=dimension else slice(j,j+size, 1) for i in range(len(self.shape))) for j in range(0,(sizedim-size) // step + 1, step)]
+        permute_index = tuple(i for i in range(dimension+1)) + tuple(len(self.shape)+1-i for i in reversed(range(dimension,len(self.shape)- dimension))) + (dimension+1,)
+        return self.cat([self[np.s_[s]].unsqueeze(dimension) for s in slices], dimension).permute(permute_index)
+
+    def unsqueeze(self, dim: int) -> Tensor:
+        new_shape = tuple(self.shape[i] for i in range(dim)) + (1,) + tuple(self.shape[i] for i in range(dim, len(self.shape)))
+        return self.reshape(new_shape)
 
     def rolling_window(self,strides:tuple, stride: int=1):
         #not sure if this belongs in the tensor class or elsewhere


### PR DESCRIPTION
using directly np.lib.stride_tricks.as_strided is both error prone and unsafe, therefore as_strided is currently removed until yadll handles memory better. Unfold has been added and can replace the use for as_strided in most cases, e.g. in rolling_window. rolling_window should be implemented using unfold, this would require refactoring the method parameters and thus also refactoring Conv and Pool layers, it should therefore be done at the same time as #19